### PR TITLE
Add example script for ONNX Runtime inference with StableDiffusion model using DML

### DIFF
--- a/test_onnxruntime.py
+++ b/test_onnxruntime.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+from transformers import AutoTokenizer
+from optimum.onnxruntime import ORTModelForCausalLM
+tokenizer = AutoTokenizer.from_pretrained("stabilityai/stablelm-3b-4e1t")
+model = ORTModelForCausalLM.from_pretrained(
+    "kazssym/stablelm-3b-4e1t-onnx-fp32",
+    provider="DmlExecutionProvider",
+)
+inputs = tokenizer("The weather is always wonderful",
+                   return_tensors="pt").to(model.device)
+tokens = model.generate(
+    **inputs,
+    max_new_tokens=64,
+    temperature=0.75,
+    top_p=0.95,
+    do_sample=True,
+)
+print(tokenizer.decode(tokens[0], skip_special_tokens=True))


### PR DESCRIPTION
This commit adds a new script `test_onnxruntime.py` demonstrating how to:

  - Load a pre-trained StableDiffusion model in ONNX format using `ORTModelForCausalLM`.
  - Specify the `DmlExecutionProvider` for DML device inference.
  - Generate text using the model with custom parameters like maximum new tokens, temperature, and top-p sampling.
  - Decode and print the generated text.

This script provides a practical example for users interested in running StableDiffusion models efficiently on DML devices with Optimum.