### PR TITLE
Test script for optimization

### DIFF
--- a/test_onnxruntime.py
+++ b/test_onnxruntime.py
@@ -2,11 +2,13 @@
 
 from transformers import AutoTokenizer
 from optimum.onnxruntime import ORTModelForCausalLM
+
 tokenizer = AutoTokenizer.from_pretrained("stabilityai/stablelm-3b-4e1t")
 model = ORTModelForCausalLM.from_pretrained(
     "kazssym/stablelm-3b-4e1t-onnx-fp32",
     provider="DmlExecutionProvider",
 )
+
 inputs = tokenizer("The weather is always wonderful",
                    return_tensors="pt").to(model.device)
 tokens = model.generate(

--- a/test_optimize.py
+++ b/test_optimize.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+from optimum.onnxruntime import ORTModelForCausalLM, ORTOptimizer, OptimizationConfig
+
+optimization_config = OptimizationConfig(99, optimize_for_gpu=False)
+
+model = ORTModelForCausalLM.from_pretrained(
+    "kazssym/stablelm-3b-4e1t-onnx-fp32",
+    #provider="DmlExecutionProvider",
+)
+optimizer = ORTOptimizer.from_pretrained(model)
+
+optimizer.optimize(optimization_config, "optimized/")


### PR DESCRIPTION
This commit optimizes the `kazssym/stablelm-3b-4e1t-onnx-fp32` model for CPU inference using the `optimum` library.

Key changes:

  * Introduces `test_optimize.py` script for optimization process.
  * Defines an `OptimizationConfig` with a target accuracy of 99% and disables GPU optimization.
  * Loads the model for optimization and creates an optimizer instance.
  * Performs optimization and saves the results to the "optimized/" directory.